### PR TITLE
Fix not using `basePath` for final image

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ export default class FullScreenshot {
         this.provider.info.scrollbarWidth,
         lastImgOffset,
         this.options.navbarOffset || 0,
-        `./screenshots/${name}-${width}.png`,
+        join(this.options.basePath, `${name}-${width}.png`),
       )
       await rimraf(baseDir)
     }


### PR DESCRIPTION
Tested locally, seems to work with this fix.

Thanks for this great library! 💯 